### PR TITLE
Escape backslashes from the paths in the generated code

### DIFF
--- a/modules/snapshots-buildtime/src/main/scala/SnapshotsBuild.scala
+++ b/modules/snapshots-buildtime/src/main/scala/SnapshotsBuild.scala
@@ -202,10 +202,13 @@ object SnapshotsBuild {
       tempPath: File,
       packageName: String,
       forceOverwrite: Boolean
-  ) =
+  ) = {
+    val escapedPath     = escapeFileName(path)
+    val escapedTempPath = escapeFileName(tempPath)
     s"""
      |package $packageName
-     |object Snapshots extends com.indoorvivants.snapshots.Snapshots(location = ${escapeFileName(path)}, tmpLocation = ${escapeFileName(tempPath)}, forceOverwrite = $forceOverwrite)
+     |object Snapshots extends com.indoorvivants.snapshots.Snapshots(location = $escapedPath, tmpLocation = $escapedTempPath, forceOverwrite = $forceOverwrite)
       """.trim.stripMargin
+  }
 
 }

--- a/modules/snapshots-buildtime/src/main/scala/SnapshotsBuild.scala
+++ b/modules/snapshots-buildtime/src/main/scala/SnapshotsBuild.scala
@@ -194,6 +194,9 @@ object SnapshotsBuild {
     Seq(sourceDestination)
   }
 
+  private def escapeFileName(path: File): String =
+    s""""${path.toString().replace("\\", "\\\\")}""""
+
   private def SnapshotsGenerate(
       path: File,
       tempPath: File,
@@ -202,7 +205,7 @@ object SnapshotsBuild {
   ) =
     s"""
      |package $packageName
-     |object Snapshots extends com.indoorvivants.snapshots.Snapshots(location = "$path", tmpLocation = "$tempPath", forceOverwrite = $forceOverwrite)
+     |object Snapshots extends com.indoorvivants.snapshots.Snapshots(location = ${escapeFileName(path)}, tmpLocation = ${escapeFileName(tempPath)}, forceOverwrite = $forceOverwrite)
       """.trim.stripMargin
 
 }


### PR DESCRIPTION
This is required for the library to work on Windows.

Otherwise, it would fail with errors like:

```
[error] 2 |object Snapshots extends com.indoorvivants.snapshots.Snapshots(location = "D:\Projects\cue4s\modules\cats-effect\src\snapshots\catsEffectJS", tmpLocation = "D:\Projects\cue4s\modules\cats-effect\target\js-3\resource_managed\test\snapshots-tmp", forceOverwrite = false)
[error]   |                                                                                             ^
[error]   |                                                  invalid escape character
```